### PR TITLE
Using Docker GitHub action

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -102,7 +102,7 @@ jobs:
         run: |
           docker buildx imagetools inspect ${{vars.DOCKER_USER}}/${{env.IMAGE_NAME}}:${{ steps.meta.outputs.version }}
     outputs:
-      tag: ${{ steps.meta.outputs.version }}
+      image-tag: ${{ steps.meta.outputs.version }}
 
   docker_test:
     if: ${{github.event.inputs.run_tests == 'true' || github.event.inputs.run_tests == null}}
@@ -120,7 +120,7 @@ jobs:
         shell: bash
         run: |
           # Run our container
-          docker run -d --name ${{env.IMAGE_NAME}} --rm ${{vars.DOCKER_USER}}/${{env.IMAGE_NAME}}:${{ needs.docker_merge.outputs.tag }}
+          docker run -d --name ${{env.IMAGE_NAME}} --rm ${{vars.DOCKER_USER}}/${{env.IMAGE_NAME}}:${{ needs.docker_merge.outputs.image-tag }}
           sleep 5 # Wait for the container to start
 
           # Check the output

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -24,8 +24,10 @@ jobs:
         include:
           - os: ${{vars.BASE_OS}}
             platform: linux/amd64
+            tag: amd64
           - os: ${{vars.BASE_OS}}-arm
             platform: linux/arm64
+            tag: arm64
     steps:
       - name: Prepare
         run: |
@@ -49,7 +51,7 @@ jobs:
         with:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          tags: ${{vars.DOCKER_USER}}/${{env.IMAGE_NAME}}, ${{vars.DOCKER_USER}}/${{env.IMAGE_NAME}}:${{matrix.platform}} 
+          tags: ${{vars.DOCKER_USER}}/${{env.IMAGE_NAME}}, ${{vars.DOCKER_USER}}/${{env.IMAGE_NAME}}:${{matrix.tag}} 
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
       - name: Export digest
         run: |

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -13,7 +13,7 @@ on:
       - main
 
 env:
-  IMAGE_NAME: githubactions-test
+  IMAGE_NAME: multi-arch-go
 
 jobs:
   docker_build:

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -56,7 +56,6 @@ jobs:
           mkdir -p ${{ runner.temp }}/digests
           digest="${{ steps.build.outputs.digest }}"
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
-
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
@@ -87,6 +86,7 @@ jobs:
         with:
           images: ${{vars.DOCKER_USER}}/${{env.IMAGE_NAME}}
           tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}
@@ -101,6 +101,8 @@ jobs:
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ${{vars.DOCKER_USER}}/${{env.IMAGE_NAME}}:${{ steps.meta.outputs.version }}
+    outputs:
+      tag: ${{ steps.meta.outputs.version }}
 
   docker_test:
     if: ${{github.event.inputs.run_tests == 'true' || github.event.inputs.run_tests == null}}
@@ -118,7 +120,7 @@ jobs:
         shell: bash
         run: |
           # Run our container
-          docker run -d --name ${{env.IMAGE_NAME}} --rm ${{vars.DOCKER_USER}}/${{env.IMAGE_NAME}}:latest
+          docker run -d --name ${{env.IMAGE_NAME}} --rm ${{vars.DOCKER_USER}}/${{env.IMAGE_NAME}}:${{ needs.docker_merge.outputs.tag }}
           sleep 5 # Wait for the container to start
 
           # Check the output

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -13,7 +13,6 @@ on:
       - main
 
 env:
-  USER: ${{secrets.DOCKER_USER}}
   IMAGE_NAME: docker-test
 
 jobs:
@@ -29,15 +28,20 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Extract Docker image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ vars.DOCKER_USER }}/${{env.IMAGE_NAME}}
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{env.USER}}
+          username: ${{vars.DOCKER_USER}}
           password: ${{secrets.DOCKER_PAT}}
       - name: Build and push
         run: |
-            docker build --tag ${{env.USER}}/${{env.IMAGE_NAME}}:${{matrix.arch}} .
-            docker push ${{env.USER}}/${{env.IMAGE_NAME}}:${{matrix.arch}}
+            docker build --tag ${{vars.DOCKER_USER}}/${{env.IMAGE_NAME}}:${{matrix.arch}} .
+            docker push ${{vars.DOCKER_USER}}/${{env.IMAGE_NAME}}:${{matrix.arch}}
 
   docker_manifest:
     needs: docker_build
@@ -46,12 +50,12 @@ jobs:
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{env.USER}}
+          username: ${{vars.DOCKER_USER}}
           password: ${{secrets.DOCKER_PAT}}
       - name: Create and push manifest
         run: |
-            docker manifest create ${{env.USER}}/${{env.IMAGE_NAME}} ${{env.USER}}/${{env.IMAGE_NAME}}:amd64 ${{env.USER}}/${{env.IMAGE_NAME}}:arm64
-            docker manifest push ${{env.USER}}/${{env.IMAGE_NAME}}
+            docker manifest create ${{vars.DOCKER_USER}}/${{env.IMAGE_NAME}} ${{vars.DOCKER_USER}}/${{env.IMAGE_NAME}}:amd64 ${{vars.DOCKER_USER}}/${{env.IMAGE_NAME}}:arm64
+            docker manifest push ${{vars.DOCKER_USER}}/${{env.IMAGE_NAME}}
 
   docker_test:
     if: ${{github.event.inputs.run_tests == 'true' || github.event.inputs.run_tests == null}}
@@ -69,7 +73,7 @@ jobs:
         shell: bash
         run: |
           # Run our container
-          docker run -d --name ${{env.IMAGE_NAME}} --rm ${{env.USER}}/${{env.IMAGE_NAME}}:latest
+          docker run -d --name ${{env.IMAGE_NAME}} --rm ${{vars.DOCKER_USER}}/${{env.IMAGE_NAME}}:latest
           sleep 5 # Wait for the container to start
 
           # Check the output

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -13,21 +13,24 @@ on:
       - main
 
 env:
-  IMAGE_NAME: docker-test
+  IMAGE_NAME: githubactions-test
 
 jobs:
   docker_build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ${{vars.BASE_OS}}
-            arch: amd64
+            platform: linux/amd64
           - os: ${{vars.BASE_OS}}-arm
-            arch: arm64
+            platform: linux/arm64
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
       - name: Extract Docker image metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -38,28 +41,70 @@ jobs:
         with:
           username: ${{vars.DOCKER_USER}}
           password: ${{secrets.DOCKER_PAT}}
-      - name: Build and push
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{vars.DOCKER_USER}}/${{env.IMAGE_NAME}}, ${{vars.DOCKER_USER}}/${{env.IMAGE_NAME}}:${{matrix.platform}} 
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+      - name: Export digest
         run: |
-            docker build --tag ${{vars.DOCKER_USER}}/${{env.IMAGE_NAME}}:${{matrix.arch}} .
-            docker push ${{vars.DOCKER_USER}}/${{env.IMAGE_NAME}}:${{matrix.arch}}
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
-  docker_manifest:
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+  
+
+  docker_merge:
     needs: docker_build
     runs-on: ${{vars.BASE_OS}}-arm
     steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{vars.DOCKER_USER}}
           password: ${{secrets.DOCKER_PAT}}
-      - name: Create and push manifest
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{vars.DOCKER_USER}}/${{env.IMAGE_NAME}}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
         run: |
-            docker manifest create ${{vars.DOCKER_USER}}/${{env.IMAGE_NAME}} ${{vars.DOCKER_USER}}/${{env.IMAGE_NAME}}:amd64 ${{vars.DOCKER_USER}}/${{env.IMAGE_NAME}}:arm64
-            docker manifest push ${{vars.DOCKER_USER}}/${{env.IMAGE_NAME}}
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{vars.DOCKER_USER}}/${{env.IMAGE_NAME}}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{vars.DOCKER_USER}}/${{env.IMAGE_NAME}}:${{ steps.meta.outputs.version }}
 
   docker_test:
     if: ${{github.event.inputs.run_tests == 'true' || github.event.inputs.run_tests == null}}
-    needs: docker_manifest
+    needs: docker_merge
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -24,10 +24,8 @@ jobs:
         include:
           - os: ${{vars.BASE_OS}}
             platform: linux/amd64
-            tag: amd64
           - os: ${{vars.BASE_OS}}-arm
             platform: linux/arm64
-            tag: arm64
     steps:
       - name: Prepare
         run: |
@@ -51,7 +49,7 @@ jobs:
         with:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          tags: ${{vars.DOCKER_USER}}/${{env.IMAGE_NAME}}, ${{vars.DOCKER_USER}}/${{env.IMAGE_NAME}}:${{matrix.tag}} 
+          tags: ${{vars.DOCKER_USER}}/${{env.IMAGE_NAME}}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
       - name: Export digest
         run: |

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@
 3. In the left sidebar, select **Secrets and variables** > **Actions**.
 4. Click the **New repository secret** button.
 5. Add the following secrets:
-    - `DOCKER_USER`: Your Docker username.
     - `DOCKER_PAT`: Your Docker Personal Access Token we generated above.
 6. Move from the **Secrets** tab to the **Variables** tab
 7. Click the **New repository variable** button.
-8. Add the following variable:
+8. Add the following variable:3
+    - `DOCKER_USER`: Your Docker username.
     - `BASE_OS`: `ubuntu-24.04`
 
 ### Run the GitHub Actions Workflow


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building and publishing Docker images, introducing multi-platform support and improving the configuration for better maintainability. It also updates the `README.md` to reflect these changes.

### Workflow Enhancements:
* Updated `.github/workflows/image-build.yml` to support multi-platform Docker image builds (`linux/amd64` and `linux/arm64`) using Docker Buildx. This replaces the previous architecture-specific builds.
* Introduced digest-based image pushing and artifact handling for better traceability and reproducibility.
* Added a new `docker_merge` job to create and push a manifest list for multi-platform images.
* Modified the `docker_test` job to use the versioned image tag output from the `docker_merge` job.

### Documentation Update:
* Updated `README.md` to move the `DOCKER_USER` configuration from secrets to repository variables, aligning with the new workflow setup.